### PR TITLE
docs: add 16 missing qbcore-packages pages

### DIFF
--- a/docs/qbcore/qbcore-packages/qb-admin.md
+++ b/docs/qbcore/qbcore-packages/qb-admin.md
@@ -1,0 +1,160 @@
+# 🛠️ qb-admin
+With great power comes a really big menu
+
+## Introduction
+qb-admin is the staff control panel. It opens a full-screen WebUI dashboard where admins can manage players, jobs and gangs, money, vitals, vehicles, the world environment, and a report/ticket queue. It also owns the server's weather and time-of-day state, syncing the sky to every client.
+
+Players use it to file reports; admins use it to review and resolve them, run quick moderation actions, and adjust the world.
+
+### Opening the panel
+The admin dashboard is bound to the **F3** key. Pressing it requests the current context from the server and opens the WebUI.
+
+```lua title="Keybind"
+Input.BindKey('F3', function() ... end, 'Released')
+```
+
+### Filing a report
+A `report` console command is registered (when the `HConsole` actor is available) that files a report to the admin queue.
+
+```text title="Console"
+report
+```
+
+/// warning
+There is no permission or ACE gate in this port — the F3 keybind and the admin server events are not restricted by a permission check in the code. Access control is expected to be enforced elsewhere (e.g. at the framework permission layer) before this resource is exposed to non-staff.
+///
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Weather
+Sets the starting time of day, starting weather, transition timing, and the table of selectable weather types (mapped to the engine `WeatherType` enum). `AnimateTime` controls whether the sky advances time on its own.
+
+```lua title="Example"
+Config.Weather = {
+    StartingTime = 1400,
+    TransitionDelay = 5, -- seconds between weather states
+    StartingWeather = 'ClearSkies',
+    AnimateTime = true,
+    WeatherTypes = {
+        ['ClearSkies'] = WeatherType.ClearSkies,
+        ['Cloudy'] = WeatherType.Cloudy,
+        ['Foggy'] = WeatherType.Foggy,
+        ['Overcast'] = WeatherType.Overcast,
+        ['PartlyCloudy'] = WeatherType.PartlyCloudy,
+        ['Rain'] = WeatherType.Rain,
+        ['RainLight'] = WeatherType.RainLight,
+        ['RainThunderstorm'] = WeatherType.RainThunderstorm,
+        ['SandDustCalm'] = WeatherType.SandDustCalm,
+        ['SandDustStorm'] = WeatherType.SandDustStorm,
+        ['Snow'] = WeatherType.Snow,
+        ['SnowBlizzard'] = WeatherType.SnowBlizzard,
+        ['SnowLight'] = WeatherType.SnowLight,
+    }
+}
+```
+
+### Locations
+The named teleport destinations available in the dashboard's developer tools. Each entry has a display `name` and `coords`. The panel lists them alphabetically by name; selecting one teleports the admin there.
+
+```lua title="Example"
+Config.Locations = {
+    apartment_lvl_1 = {
+        name = 'Apartment (Lvl 1)',
+        coords = Vector(567648, 552846, 4561),
+    },
+    gas_station = {
+        name = 'Gas Station',
+        coords = Vector(563566, 561573, 4563),
+    },
+    vehicle_shop = {
+        name = 'Vehicle Shop',
+        coords = Vector(569726, 543631, 4558),
+    },
+    casino = {
+        name = 'Casino',
+        coords = Vector(582568, 609758, 4584),
+    },
+    -- ...apartments lvl 1-5, clothing/fishing/mechanic shops, mining area,
+    -- cinema, shopping mall, industrial/residential areas, parking lot, etc.
+}
+```
+
+## Features
+
+The dashboard is organized into pages, each backed by server events. Below is what the code actually implements.
+
+### Dashboard
+On open, the panel is populated with live stats (players online, server uptime, ping), the disciplinary feed, the report/ticket queue, the player list, an action/log history, and a wealth leaderboard. It also exposes a set of self/quick actions:
+
+- **Noclip** — toggles flying movement and disables collision on the admin.
+- **God Mode** — toggles invincibility on the admin.
+- **Invisibility** — hides the admin in-game.
+- **Self Heal** / **Self Revive** — heals or revives the admin and resets vitals.
+- **Overhead Names** — toggles overhead name display _(TO DO — not yet implemented)_.
+- **Admin Duty** — toggle state is tracked and logged only _(TO DO — no effect applied yet)_.
+- **Announce** — broadcasts a dashboard announcement to clients.
+
+### Player Management
+For any player in the list, admins can run:
+
+- **Quick controls**: teleport-to, bring-to-you, spectate, kick, ban, freeze, kill, revive, open clothing, open inventory.
+- **Context actions**: spectate, quick-kick, bring, freeze, heal.
+- **Vitals**: replenish health, armor, hunger, or thirst.
+- **Currency**: add, remove, or set `cash`, `bank`, or `crypto` (routed through the qb-core player money methods, fully logged).
+- **Jobs**: fire (set to `unemployed`) or change job + grade.
+- **Gangs**: remove (set to `none`) or change gang + grade.
+
+Job, gang, item, and vehicle catalogs shown in the menu are pulled from qb-core via `GetShared`.
+
+/// note
+A few player tools are scaffolded but not finished: **spectate** (camera attach), **ban** (persisted bans / duration / reason), **overhead names**, and the vehicle **ownership**, **glovebox**, and **trunk** viewers are marked `TO DO` in the code and currently only fire placeholder events or log the action.
+///
+
+### Vehicle Actions
+Acting on a player's currently occupied vehicle: **repair**, **refuel** (to 100%), **delete**, and the placeholder **ownership** / **glovebox** / **trunk** viewers noted above.
+
+### Developer Tools
+- **Teleport to location** (from `Config.Locations`) or **to raw coordinates**.
+- **Spawn vehicle** in front of the admin (from the shared vehicles catalog).
+- **Spawn object** _(TO DO — awaiting an object catalog/asset mapping)_.
+- **Copy coordinates / rotation / heading** of the admin's pawn to the clipboard.
+- **Run console command** through the `HConsole` actor.
+
+### Environment
+- **Change weather** and **change time** — updates the server's stored state and broadcasts it to all clients, which re-sync their sky.
+- **Cleanup** nearby entities: vehicles (50m), peds (50m), objects (50m), or everything (100m). Player-controlled characters are skipped.
+
+### Reports & Tickets
+Reports filed by players become tickets in a kanban-style queue (`incoming` → `in-progress` → `resolved`).
+
+- **Update state** — move a ticket between columns and assign an owner.
+- **Resolve** — mark a ticket resolved with a resolution note.
+- **Clear resolved** — remove resolved tickets from the queue.
+- **Investigation actions** on the reporter — goto, bring, heal, freeze.
+
+All report, ticket, chat, and log state is kept in-memory on the server (capped lists) and is not persisted to the database.
+
+## Events
+
+These are the resource's main server events. Most are triggered from the WebUI via the client bridge; you generally won't call them directly.
+
+| Event | Purpose |
+| --- | --- |
+| `qb-admin:server:fileReport` | File a new report / open a ticket |
+| `qb-admin:server:players:quickControl` | Quick moderation actions (kick, ban, freeze, etc.) |
+| `qb-admin:server:players:context-action` | Context-menu actions (spectate, heal, bring, etc.) |
+| `qb-admin:server:players:vehicleAction` | Repair / refuel / delete occupied vehicle |
+| `qb-admin:server:players:jobAction` | Fire or change a player's job |
+| `qb-admin:server:players:gangAction` | Remove or change a player's gang |
+| `qb-admin:server:players:replenishVital` | Restore health / armor / hunger / thirst |
+| `qb-admin:server:players:currencyAdjust` | Add / remove / set player money |
+| `qb-admin:server:dashboard:quickAction` | Self actions (noclip, god mode, invis, self heal, etc.) |
+| `qb-admin:server:dashboard:announce` | Broadcast a server announcement |
+| `qb-admin:server:environment:cleanup` | Clear nearby entities |
+| `qb-admin:server:changeWeather` / `qb-admin:server:changeTime` | Set world weather / time |
+| `qb-admin:server:reports:updateState` / `:resolved` / `:clearResolved` / `:investigationAction` | Manage the report/ticket queue |
+
+/// info
+qb-admin exposes no `exports['qb-admin']` functions for other resources to call — it is driven entirely through its WebUI and the server events above.
+///

--- a/docs/qbcore/qbcore-packages/qb-ambulancejob.md
+++ b/docs/qbcore/qbcore-packages/qb-ambulancejob.md
@@ -1,0 +1,118 @@
+# 🚑 qb-ambulancejob
+Someone call a medic?
+
+## Introduction
+
+The Emergency Medical Services job. Gives on-duty paramedics the tools to get patients back on their feet:
+
+- Hospital check-in, duty toggle and a shared EMS stash
+- Grade-gated ambulances and helicopters, spawned with `AMBU` and `LIFE` plates respectively
+- Treat any player through a [qb-target](qb-target.md) global-player menu: check health status, revive, bandage and escort
+- Hospital and jail beds players can lie in to recover
+- A skeletal limb (bone) map used to identify which body part was injured
+
+/// warning
+Every coordinate in `Config.VehicleSpawn`, `Config.HelicopterSpawn` and `Config.Locations` ships as a `Vector(0, 0, 0)` placeholder. You must set these per-map before the job is usable in your world.
+///
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Vehicle & Helicopter Spawns
+Where retrieved ambulances and helicopters appear. Both ship as `Vector(0, 0, 0)` placeholders.
+
+```lua title="Example"
+Config.VehicleSpawn    = { coords = Vector(0, 0, 0), heading = 0 },
+Config.HelicopterSpawn = { coords = Vector(0, 0, 0), heading = 0 },
+```
+
+### Locations
+All hospital interaction points. Every coordinate is a `Vector(0, 0, 0)` placeholder to be set per-map.
+
+- `checking`: hospital check-in points
+- `duty`: duty-toggle point
+- `vehicle`: ambulance retrieval point
+- `helicopter`: helicopter retrieval point
+- `stash`: shared EMS stash
+- `jailbeds`: recovery beds with a `taken` flag and bed `model`
+- `hospital`: named hospitals, each with a `location` and a list of `beds`
+- `stations`: station blip/label points
+
+```lua title="Example"
+Config.Locations = {
+    ['checking'] = {
+        { coords = Vector(0, 0, 0) },
+        { coords = Vector(0, 0, 0) }
+    },
+    ['duty'] = {
+        { coords = Vector(0, 0, 0), rotation = Rotator(0, 0, 0) }
+    },
+    ['vehicle'] = {
+        { coords = Vector(0, 0, 0) }
+    },
+    ['helicopter'] = {
+        { coords = Vector(0, 0, 0) }
+    },
+    ['stash'] = {
+        { coords = Vector(0, 0, 0) }
+    },
+    ['jailbeds'] = {
+        { coords = Vector(0, 0, 0), taken = false, model = '/QBCoreAssets/Meshes/LP_HospitalBed.LP_HospitalBed' },
+        -- ...
+    },
+    ['hospital'] = {
+        {
+            ['name']     = Lang.t('info.pb_hospital'), -- 'Pillbox Hospital'
+            ['location'] = Vector(0, 0, 0),
+            ['beds'] = {
+                { coords = Vector(0, 0, 0), heading = 0, taken = false },
+                -- ...
+            },
+        },
+    },
+    ['stations'] = {
+        { label = Lang.t('info.pb_hospital'), coords = Vector(0, 0, 0) }
+    }
+}
+```
+
+### Authorized Vehicles & Helicopters
+Grade-gated spawn lists. The grade is the table key and acts as a minimum — higher ranks can also spawn anything available to lower grades. Ambulances spawn with an `AMBU` plate and helicopters with a `LIFE` plate, each followed by four random digits.
+
+```lua title="Example"
+Config.AuthorizedVehicles = {
+    [0] = {
+        ['bp_ambulance'] = 'Ambulance'
+    }
+}
+
+Config.AuthorizedHelicopters = {
+    [0] = {
+        ['bp_aheli'] = 'EMS Heli'
+    }
+}
+```
+
+### Bones
+A map of skeleton bone names to their engine identifiers, used to determine which limb was hit when assessing a patient's injuries. The table is extensive (full skeleton); a short excerpt is shown below.
+
+```lua title="Example"
+Config.Bones = {
+    ['Head']          = 'head',
+    ['Neck']          = 'neck_01',
+    ['Spine']         = 'spine_01',
+    ['LeftArm']       = 'upperarm_l',
+    ['RightArm']      = 'upperarm_r',
+    ['LeftForeArm']   = 'lowerarm_l',
+    ['RightForeArm']  = 'lowerarm_r',
+    ['LeftHand']      = 'hand_l',
+    ['RightHand']     = 'hand_r',
+    ['LeftThigh']     = 'thigh_l',
+    ['RightThigh']    = 'thigh_r',
+    ['LeftCalf']      = 'calf_l',
+    ['RightCalf']     = 'calf_r',
+    ['LeftFoot']      = 'foot_l',
+    ['RightFoot']     = 'foot_r',
+    -- ...full skeleton continues
+}
+```

--- a/docs/qbcore/qbcore-packages/qb-consumables.md
+++ b/docs/qbcore/qbcore-packages/qb-consumables.md
@@ -1,0 +1,44 @@
+# 🍔 qb-consumables
+Snack attack
+
+## Introduction
+Registers food and drink items as usable through [qb-core](qb-core.md). When a player uses a consumable, its configured hunger or thirst value is added to the player's metadata and one of the item is removed from their [qb-inventory](qb-inventory.md).
+
+## Configuration
+The consumables are defined inline in the `server.lua` `Consumables` table rather than in a `config.lua`. Each entry maps an item name to the `hunger` or `thirst` amount it restores. On startup the package loops over this table and calls `exports['qb-core']:CreateUseableItem` for every item.
+
+```lua title="Consumables"
+local Consumables = {
+    -- Food
+    tosti         = { hunger = 40 },
+    sandwich      = { hunger = 35 },
+    fish          = { hunger = 30 },
+    grape         = { hunger = 15 },
+    twerks_candy  = { hunger = 10 },
+    snikkel_candy = { hunger = 10 },
+    -- Drinks
+    water_bottle  = { thirst = 40 },
+    grapejuice    = { thirst = 25 },
+    kurkakola     = { thirst = 25 },
+    coffee        = { thirst = 20 },
+    beer          = { thirst = 20 },
+    wine          = { thirst = 20 },
+    whiskey       = { thirst = 15 },
+    vodka         = { thirst = 15 },
+}
+```
+
+### Adding a Consumable
+Add a new line to the `Consumables` table with the item name as the key and the effect as the value. Use `hunger` for food and `thirst` for drinks.
+
+```lua title="Example"
+local Consumables = {
+    -- ...existing entries...
+    burger = { hunger = 50 },
+    soda   = { thirst = 30 },
+}
+```
+
+/// warning
+Any item you add here must also exist in the qb-core `Shared.Items` table. If the item is not defined there it cannot be created as a usable item and will not work.
+///

--- a/docs/qbcore/qbcore-packages/qb-core.md
+++ b/docs/qbcore/qbcore-packages/qb-core.md
@@ -1,0 +1,295 @@
+# ⚙️ qb-core
+The engine room of the whole framework
+
+## Introduction
+qb-core is the foundation every other resource depends on. It loads and exposes the shared catalogs (jobs, gangs, items, vehicles, weapons, locations), manages player data and persistence, handles money/job/gang/metadata, and exposes a wide export surface so other resources never have to touch the database directly.
+
+The global `QBCore` object lives on the server with three core tables:
+
+- `QBCore.Functions` — server-side helper functions (player lookups, useable items, ID generators).
+- `QBCore.Player` — the player class plus login/logout/save logic.
+- `QBCore.Shared` — the loaded catalogs (`Jobs`, `Gangs`, `Items`, `Vehicles`, `Weapons`, `Locations`, `StarterItems`).
+
+Most other resources reach this functionality through `exports['qb-core']`.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Default Spawn
+The world location new and returning characters are placed at when no saved position exists.
+
+```lua title="Example"
+QBCore.Config.DefaultSpawn = Vector(-1035.71, -2731.87, 12.86)
+```
+
+### Max Players
+The maximum number of concurrent players.
+
+```lua title="Example"
+QBCore.Config.MaxPlayers = 48
+```
+
+### Update & Status Intervals
+How often player data is saved, and how often hunger/thirst status is recalculated.
+
+```lua title="Example"
+QBCore.Config.UpdateInterval = 5    -- minutes between player data saves
+QBCore.Config.StatusInterval = 5000 -- milliseconds between hunger/thirst checks
+```
+
+### Money
+Defines the money types available on the server and their starting balances. Each key is a money type and its value is the amount new characters start with. `DontAllowMinus` lists types that can never go negative, and `MinusLimit` caps how far any other type may go.
+
+```lua title="Example"
+QBCore.Config.Money = {}
+QBCore.Config.Money.MoneyTypes = { cash = 500, bank = 5000, crypto = 0 }
+QBCore.Config.Money.DontAllowMinus = { 'cash', 'crypto' }
+QBCore.Config.Money.MinusLimit = -5000
+QBCore.Config.Money.PayCheckTimeOut = 10    -- minutes between paychecks
+QBCore.Config.Money.PayCheckSociety = false -- pull paycheck from society account (requires qb-management)
+```
+
+/// info
+Once a money type is added it is written to the database and will not be removed even if you delete it from the config.
+///
+
+### Player Vitals
+Controls how fast hunger and thirst decay, and the list of blood types randomly assigned to new characters.
+
+```lua title="Example"
+QBCore.Config.Player.HungerRate = 4.2 -- rate at which hunger goes down
+QBCore.Config.Player.ThirstRate = 3.8 -- rate at which thirst goes down
+QBCore.Config.Player.Bloodtypes = {
+    'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-',
+}
+```
+
+### Player Defaults
+The template applied to every new character. It defines starting money, charinfo, default job (`unemployed` / Civilian), default gang (`none`), and the full metadata block (hunger, thirst, stress, licences, callsign, fingerprint, and so on). Values defined as functions (e.g. `citizenid`, `phone`, `fingerprint`) are generated per character.
+
+```lua title="Example"
+QBCore.Config.Player.PlayerDefaults = {
+    citizenid = function() return QBCore.Functions.CreateCitizenId() end,
+    cid = 1,
+    money = function()
+        local moneyDefaults = {}
+        for moneytype, startamount in pairs(QBCore.Config.Money.MoneyTypes) do
+            moneyDefaults[moneytype] = startamount
+        end
+        return moneyDefaults
+    end,
+    job = {
+        name = 'unemployed',
+        label = 'Civilian',
+        payment = 10,
+        type = 'none',
+        onduty = false,
+        isboss = false,
+        grade = { name = 'Freelancer', level = 0 }
+    },
+    gang = {
+        name = 'none',
+        label = 'No Gang Affiliation',
+        isboss = false,
+        grade = { name = 'none', level = 0 }
+    },
+    metadata = {
+        hunger = 100,
+        thirst = 100,
+        stress = 0,
+        isdead = false,
+        armor = 0,
+        ishandcuffed = false,
+        -- ...callsign, fingerprint, licences, phonedata, etc.
+    },
+    position = QBCore.Config.DefaultSpawn,
+    items = {},
+}
+```
+
+### Starter Items
+The items every new character receives. Defined in `Shared/functions.lua`.
+
+```lua title="Example"
+QBCore.Shared.StarterItems = {
+    ['phone'] = { amount = 1, item = 'phone' },
+    ['id_card'] = { amount = 1, item = 'id_card' },
+    ['driver_license'] = { amount = 1, item = 'driver_license' },
+}
+```
+
+### Server
+General server-level settings such as whitelist, PVP, and the permission groups recognized by the framework.
+
+```lua title="Example"
+QBCore.Config.Server.Closed = false
+QBCore.Config.Server.Whitelist = false
+QBCore.Config.Server.PVP = true
+QBCore.Config.Server.Permissions = { 'god', 'admin', 'mod' }
+```
+
+/// note
+The legacy chat commands in `Server/commands.lua` (`id`, `addpermission`, `car`, `weapon`, etc.) are fully commented out in this port and do not register. Treat that file as inactive.
+///
+
+## Functions
+
+These are the most commonly used exports other resources call. Every function on `QBCore.Functions` and `QBCore.Player` is bridged to `exports['qb-core']` automatically, so the names below match their Lua definitions exactly.
+
+### GetPlayer
+Returns the player object for a connected player. Accepts either a numeric source id or the player handle.
+
+- source `number` or `player` - The player source
+
+```lua title="Example"
+local Player = exports['qb-core']:GetPlayer(source)
+if Player then
+    print(Player.PlayerData.citizenid)
+end
+```
+
+### GetPlayerByCitizenId
+Returns the online player object matching a citizen id, or `nil` if they are not connected.
+
+- citizenid `string`
+
+```lua title="Example"
+local Player = exports['qb-core']:GetPlayerByCitizenId('ABC12345')
+```
+
+### GetPlayers
+Returns an array of the sources of all currently connected players.
+
+```lua title="Example"
+local players = exports['qb-core']:GetPlayers()
+for i = 1, #players do
+    local Player = exports['qb-core']:GetPlayer(players[i])
+end
+```
+
+### CreateUseableItem
+Registers a callback that runs when a player uses the named item from their inventory.
+
+- item `string` - The item name
+- data `function` - Handler invoked when the item is used
+
+```lua title="Example"
+exports['qb-core']:CreateUseableItem('water', function(source, item)
+    local Player = exports['qb-core']:GetPlayer(source)
+    Player.Functions.SetMetaData('thirst', 100)
+end)
+```
+
+### GetShared
+Returns a loaded shared catalog, or a single entry within it.
+
+- namespace `string` - One of `Vehicles`, `VehicleHashes`, `Items`, `Gangs`, `Jobs`, `Locations`, `Weapons`, `StarterItems`
+- item `string` _(optional)_ - A specific key inside the namespace
+
+```lua title="Example"
+local allJobs = exports['qb-core']:GetShared('Jobs')
+local water   = exports['qb-core']:GetShared('Items', 'water')
+```
+
+### GetCoreObject
+Returns the full `QBCore` table, or a filtered subset when given a list of keys.
+
+- filters `table` _(optional)_ - List of top-level keys to return (e.g. `Functions`, `Players`, `Shared`)
+
+```lua title="Example"
+local QBCore = exports['qb-core']:GetCoreObject()
+```
+
+### Catalog Management
+The shared catalogs can be extended at runtime. Each call updates the in-memory catalog and broadcasts the change to connected clients. All return `success` as the first value.
+
+- `AddJob(jobName, job)` / `AddJobs(jobs)` / `UpdateJob(jobName, job)` / `RemoveJob(jobName)`
+- `AddItem(itemName, item)` / `AddItems(items)` / `UpdateItem(itemName, item)` / `RemoveItem(itemName)`
+- `AddGang(gangName, gang)` / `AddGangs(gangs)` / `UpdateGang(gangName, gang)` / `RemoveGang(gangName)`
+- `SetMethod(methodName, handler)` / `SetField(fieldName, data)` - extend the `QBCore` table itself
+
+```lua title="Example"
+exports['qb-core']:AddItem('lockpick', {
+    name = 'lockpick',
+    label = 'Lockpick',
+    weight = 100,
+    type = 'item',
+    unique = false,
+    useable = true,
+})
+```
+
+## Player Object Methods
+
+A player object returned by `GetPlayer` exposes `PlayerData` (the raw character data) and `Functions` (the methods below). These run server-side and automatically sync the relevant data to the client.
+
+### AddMoney
+Adds money of the given type. Logs the transaction and notifies the client.
+
+- moneytype `string` - `cash`, `bank`, `crypto`, etc.
+- amount `number`
+- reason `string` _(optional)_ - Logged reason, defaults to `'unknown'`
+
+```lua title="Example"
+Player.Functions.AddMoney('bank', 2500, 'paycheck')
+```
+
+### RemoveMoney
+Removes money of the given type. Respects `DontAllowMinus` and `MinusLimit`; returns `false` if the player cannot afford it.
+
+- moneytype `string`
+- amount `number`
+- reason `string` _(optional)_
+
+```lua title="Example"
+if Player.Functions.RemoveMoney('cash', 100, 'shop-purchase') then
+    -- payment succeeded
+end
+```
+
+### SetJob
+Sets the player's job to the given name and grade. Returns `false` if the job does not exist in the shared catalog.
+
+- job `string` - Job name
+- grade `number` _(optional)_ - Grade level, defaults to `1`
+
+```lua title="Example"
+Player.Functions.SetJob('police', 2)
+```
+
+### SetGang
+Sets the player's gang and grade. Returns `false` if the gang does not exist.
+
+- gang `string` - Gang name
+- grade `number` _(optional)_ - Grade level, defaults to `1`
+
+```lua title="Example"
+Player.Functions.SetGang('ballas', 1)
+```
+
+### SetMetaData
+Sets a metadata field on the character. `hunger`, `thirst`, `stress`, and `armor` are automatically clamped to `0`–`100`.
+
+- meta `string` - Metadata key
+- val `any` - New value
+
+```lua title="Example"
+Player.Functions.SetMetaData('hunger', 100)
+Player.Functions.SetMetaData('ishandcuffed', true)
+```
+
+### AddMethod
+Adds (or overrides) a method on this specific player object at runtime.
+
+- methodName `string`
+- handler `function`
+
+```lua title="Example"
+Player.Functions.AddMethod('GreetPlayer', function()
+    print('Hello ' .. Player.PlayerData.charinfo.firstname)
+end)
+```
+
+/// tip
+Other useful player methods include `SetMoney`, `GetMoney`, `CanAfford`, `GetJob`, `GetGang`, `SetJobDuty`, `IsOnDuty`, `GetMetaData`, `HasItem`, `HasLicence`, `SetLicence`, `AddRep` / `RemoveRep` / `GetRep`, and `Save`.
+///

--- a/docs/qbcore/qbcore-packages/qb-deliveryjob.md
+++ b/docs/qbcore/qbcore-packages/qb-deliveryjob.md
@@ -1,0 +1,77 @@
+# 📦 qb-deliveryjob
+Sign here, please.
+
+## Introduction
+A courier job where players run packages along a randomly generated multi-stop route:
+
+- Talk to the depot NPC to start delivering; a delivery truck spawns for you.
+- Target the truck to pick up a box. Your character carries the box and a guidance cone appears, rotating to point toward the next drop-off.
+- Drive to the highlighted location and press `[E]` to deliver the package, then return for the next box.
+- After the final stop, return the truck to the depot to collect payment. Payout scales with how much of the route you finished.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Job, Stops and Payout
+Top-level options control the required job name, how many stops a route has, and the random pay range. The number of stops is rolled between `Stops.Minimum` and `Stops.Maximum`; the payout is rolled between `Payout.Minimum` and `Payout.Maximum`.
+
+```lua title="Example"
+Config = {
+    Job = 'delivery',
+    Stops  = { Minimum = 3, Maximum = 5 },
+    Payout = { Minimum = 500, Maximum = 1000 },
+}
+```
+
+/// info
+Payout is reduced for incomplete routes: you receive nothing if you delivered no packages, and roughly 30% of the rolled amount if you returned the truck before finishing every stop.
+///
+
+### Depots
+Each depot defines the NPC location (`pedSpawn`) and where the delivery truck spawns (`vehicleSpawn`). The NPC offers start-delivering and finish-delivering target options.
+
+```lua title="Example"
+Config.Depots = {
+    {
+        label = 'Test',
+        pedSpawn = { coords = Vector(-355239.42, -132407.13, -2882.44), heading = 176, },
+        vehicleSpawn = { coords = Vector(-355929.31, -132383.51, -2897.84), heading = 180, },
+    }
+}
+```
+
+### Vehicles
+A list of vehicle keys from the qb-core Shared `Vehicles` table. One is picked at random per job (falling back to `bp_deliverytruck`).
+
+```lua title="Example"
+Config.Vehicles = {
+    'bp_deliverytruck'
+}
+```
+
+### Locations
+The pool of possible drop-off points. Each route is drawn randomly from this list, sorted by proximity from the closest starting point. If too few locations are selected for the rolled stop count, the route is regenerated.
+
+```lua title="Example"
+Config.Locations = {
+    Vector(-316430.68, -130243.49, -3391.50),
+    Vector(-314462.63, -120730.97, -3358.08),
+    Vector(-314610.22, -119405.93, -3356.28),
+    Vector(-315755.85, -112270.68, -3346.73),
+    Vector(-343143.34, -145299.86, -2882.38)
+}
+```
+
+### Prop
+The carried package mesh and the holding animation used while a courier is carrying a box.
+
+```lua title="Example"
+Config.Prop = {
+    Mesh = '/Engine/BasicShapes/Cube.Cube',
+    HoldingAnimation = '/Game/Characters/Heroes/Unified/Animations/Package_Deliveryman/Carrying/A_Carrying_BothArms_LargeBox_Holding_Idle.A_Carrying_BothArms_LargeBox_Holding_Idle'
+}
+```
+
+/// info
+The navigation cone is an `SM_Cone` mesh attached to the player. A timer continuously re-aims it toward the current drop-off using `FindLookAtRotation`, giving the courier a live pointer to the next stop.
+///

--- a/docs/qbcore/qbcore-packages/qb-fishing.md
+++ b/docs/qbcore/qbcore-packages/qb-fishing.md
@@ -1,0 +1,93 @@
+# 🎣 qb-fishing
+Just keep casting
+
+## Introduction
+Places fishing spots around the map using [qb-target](qb-target.md) sphere zones. Players interact with a spot, complete a minigame, and receive a fish through [qb-inventory](qb-inventory.md).
+
+The fishing loop is:
+
+1. Each configured zone spawns a marker and a `qb-target` sphere zone with a **Start Fishing** option.
+2. Selecting it briefly gives the player a fishing rod (`ID_Misc_FishingRod`) and opens the fishing minigame (a `WebUI` panel).
+3. On a successful minigame the server adds that water type's `reward` item to the player's inventory.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Global Options
+- fishingTime: `number`
+
+`fishingTime` is the duration in milliseconds used by the minigame.
+
+```lua title="Example"
+Config = {
+    fishingTime = 10000,
+}
+```
+
+### Water Types
+`waterTypes` is a table keyed by a unique identifier. Each water type defines a label, the reward item caught there, and a list of `zones` (each a `coords` point that becomes a fishing sphere zone).
+
+- id: `string`
+- label: `string`
+- reward: `string`
+- zones: `table`
+
+Each entry in `zones` is a `{ coords = Vector(x, y, z) }` point. A 100-unit `qb-target` sphere zone is created at each one.
+
+```lua title="Example"
+Config = {
+    fishingTime = 10000,
+    waterTypes = {
+        ocean = {
+            id = "ocean",
+            label = "Ocean",
+            reward = "fish",
+            zones = {
+                { coords = Vector(606302, 628637, 4703) },
+                { coords = Vector(606019, 628637, 4703) },
+                { coords = Vector(605737, 628637, 4703) },
+            },
+        },
+        lake = {
+            id = "lake",
+            label = "Lake",
+            reward = "fish",
+            zones = {
+                { coords = Vector(526826, 513713, 4570) },
+                { coords = Vector(526984, 516069, 4570) },
+            },
+        },
+        river = {
+            id = "river",
+            label = "River",
+            reward = "fish",
+            zones = {
+                { coords = Vector(526857, 502417, 4594) },
+                { coords = Vector(527152, 502330, 4594) },
+            },
+        },
+        swamp = {
+            id = "swamp",
+            label = "Swamp",
+            reward = "fish",
+            zones = {
+                { coords = Vector(526212, 505121, 4570) },
+                { coords = Vector(526211, 505321, 4570) },
+            },
+        },
+        deep_sea = {
+            id = "deep_sea",
+            label = "Deep Sea",
+            reward = "fish",
+            zones = {
+                { coords = Vector(624520, 627591, 4394) },
+                { coords = Vector(625256, 627634, 4392) },
+            },
+        },
+    },
+}
+```
+
+/// tip
+The `reward` item for each water type must also exist in the qb-core `Shared.Items` table, otherwise it cannot be added to the player's inventory. In the shipped config every water type rewards `fish`.
+///

--- a/docs/qbcore/qbcore-packages/qb-fuel.md
+++ b/docs/qbcore/qbcore-packages/qb-fuel.md
@@ -1,0 +1,25 @@
+# ⛽ qb-fuel
+Empty tank, empty promises.
+
+## Introduction
+qb-fuel is intended to handle vehicle refueling at gas stations. Right now it only attaches [qb-target](qb-target.md) interaction options to the configured pump models.
+
+/// warning
+This package is a **stub / work-in-progress**. It registers "Fuel Can" and "Refuel" target options on every pump model in `Config.pumpModels`, but both options point at an empty event name (`'qb-fuel:'`) that has **no handler**. There is no working refuel logic, no jerry-can behavior, and no payment. The server file is empty. Pressing the target options does nothing today.
+///
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Pump Models
+`Config.pumpModels` is a list of static mesh model names that get the fuel target options attached. Each listed model gains a target with two options ("Fuel Can" / "Refuel"), both wired to the placeholder `'qb-fuel:'` event.
+
+- pumpModels: `table` — list of pump mesh names
+
+```lua title="Example"
+Config = {
+    pumpModels = { 'SM_Downtown_PetrolStation_Pump_01B' }
+}
+
+return Config
+```

--- a/docs/qbcore/qbcore-packages/qb-garages.md
+++ b/docs/qbcore/qbcore-packages/qb-garages.md
@@ -1,0 +1,92 @@
+# 🅿️ qb-garages
+Park it, then go find it again.
+
+## Introduction
+qb-garages lets players store and retrieve their owned vehicles. Walking into a garage zone and pressing **E** on foot opens the garage menu to take a vehicle out; pressing **E** while sitting in a vehicle deposits it. Garages can be public, locked to a job or gang, tied to a house, or act as a depot/impound that charges a release fee.
+
+Vehicle metadata comes from the shared vehicle list (`exports['qb-core']:GetShared('Vehicles')`); vehicle ownership and state live in the `player_vehicles` database table.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Global Options
+Top-level toggles controlling how garages behave.
+
+- AutoRespawn: `boolean` — `true` stores all out vehicles back into their garage on restart; `false` leaves vehicle states untouched
+- VisuallyDamageCars: `boolean` — `true` applies stored damage to a vehicle on spawn; `false` spawns it clean
+- SharedGarages: `boolean` — `true` lets a player take any of their vehicles from any garage; `false` restricts retrieval to the garage the vehicle was stored in
+- ClassSystem: `boolean` — `true` restricts vehicles by class; `false` allows any class in any garage
+- Warp: `boolean` — `true` warps the player into the vehicle on spawn; `false` spawns it without warping
+
+```lua title="Example"
+Config.AutoRespawn = true
+Config.VisuallyDamageCars = true
+Config.SharedGarages = false
+Config.ClassSystem = false
+Config.Warp = true
+
+Config.VehicleClass = UE.EHelixVehicleType
+```
+
+### Garages
+`Config.Garages` is a table indexed by a unique garage id. Each garage defines where the access zone is, where vehicles spawn, who may use it, and which vehicle category it accepts.
+
+- label: `string` — display name shown in menus
+- takeVehicle: `Vector` — center of the access zone (where the player stands to open the garage)
+- spawnPoint: `table` — one or more `{ coords = Vector, heading = number }` entries where retrieved vehicles spawn
+- type: `string` — `'public'`, `'job'`, `'gang'`, `'depot'`, or `'house'`
+- category: `Config.VehicleClass.*` — accepted vehicle type (e.g. `Config.VehicleClass.Car`)
+- <mark style="color:yellow;">job</mark>: `string` — required job name (for `type = 'job'`)
+- <mark style="color:yellow;">jobType</mark>: `string` — required job type, e.g. `'leo'` or `'ems'` (for `type = 'job'`)
+
+/// info
+A `job`-type garage opens when the player's job name matches `job` **or** their job type matches `jobType`. A `gang`-type garage matches the player's gang against the garage's `job` field. `public` garages are open to everyone, and `depot` garages list impounded vehicles for paid release.
+///
+
+```lua title="Example"
+Config.Garages = {
+    apartment1 = {
+        label = 'Brightside Motel',
+        takeVehicle = Vector(576131, 597559, 4553),
+        spawnPoint = {
+            {
+                coords = Vector(576031, 596919, 4553),
+                heading = 177,
+            }
+        },
+        type = 'public', -- public, gang, job, depot
+        category = Config.VehicleClass.Car
+    },
+    police = {
+        label = 'Police',
+        takeVehicle = Vector(-340755, -145572, -2885),
+        spawnPoint = {
+            coords = Vector(-340842, -145021, -2885),
+            heading = 180,
+        },
+        type = 'job',
+        category = Config.VehicleClass['car'], -- car, air, sea, rig
+        job = 'police',
+        jobType = 'leo'
+    },
+}
+```
+
+/// tip
+Several blip fields (`showBlip`, `blipName`, `blipNumber`, `blipColor`) appear in the config but are currently unused — blip creation is commented out in the client.
+///
+
+### Depot / Impound
+A garage with `type = 'depot'` lists vehicles that have an impound fee (`depotprice > 0` in `player_vehicles`). Taking a vehicle out triggers `qb-garages:server:PayDepotPrice`, which charges the stored `depotprice` from the player's `cash` (or `bank` if cash is short) before spawning it. Vehicles with no fee are released for free. When `Config.AutoRespawn` runs on restart, vehicles left out are reset and assigned a depot price.
+
+## Functions
+
+### getAllGarages
+Returns a flat list of all configured garages, intended for other resources (for example a phone app) to enumerate available garages. Each entry contains `name`, `label`, `type`, `takeVehicle`, `putVehicle`, `spawnPoint`, `showBlip`, `blipName`, `blipNumber`, `blipColor`, and `vehicle`.
+
+```lua title="Example"
+local garages = exports['qb-garages']:getAllGarages()
+for i = 1, #garages do
+    print(garages[i].name, garages[i].label, garages[i].type)
+end
+```

--- a/docs/qbcore/qbcore-packages/qb-garbagejob.md
+++ b/docs/qbcore/qbcore-packages/qb-garbagejob.md
@@ -1,0 +1,62 @@
+# 🗑️ qb-garbagejob
+One man's trash...
+
+## Introduction
+A sanitation job built around a collect-deposit-repeat route loop:
+
+- Talk to the Garbage Depot NPC to go on duty and start a job; a garbage truck spawns and you're assigned a random number of stops.
+- Target a dumpster (`SM_Dumpster`) to collect a trash bag — your character is handed an `ID_Misc_TrashBag` item to carry.
+- Target the garbage truck to deposit the bag. Each deposit completes a stop and pays out a random per-bag amount.
+- Once every stop is done, return the truck to the depot and complete the route to collect your earnings.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Stops and Bag Worth
+Top-level options control how many stops a route has and the per-bag pay range. The stop count is rolled between `MinStops` and `MaxStops`; each deposited bag pays a random amount between `BagLowerWorth` and `BagUpperWorth`, accumulated into the route total.
+
+- MinStops / MaxStops: `number` — bounds for the random number of stops per route.
+- BagLowerWorth / BagUpperWorth: `number` — bounds for the random pay added per deposited bag.
+
+```lua title="Example"
+Config = {
+    Vehicle = '/abcca-qbcore-veh/QBCoreVehicles/BP_Garbage_Truck.BP_Garbage_Truck_C',
+    MinStops = 3,
+    MaxStops = 10,
+    BagLowerWorth = 300,
+    BagUpperWorth = 1000,
+}
+```
+
+### Depots
+Each depot defines the duty NPC location (`pedSpawn`) and where the garbage truck spawns (`vehicleSpawn`). The NPC offers toggle-duty, start-job, and complete-route target options.
+
+```lua title="Example"
+Config.Locations = {
+    Depots = {
+        {
+            label = 'West Garbage Depot',
+            pedSpawn = { coords = Vector(-355218, -133170, -2882), heading = 176 },
+            vehicleSpawn = { coords = Vector(-356090, -133100, -2981), heading = 180 },
+        },
+    },
+}
+```
+
+### Dumpsters
+Each entry spawns an `SM_Dumpster` mesh that can be targeted to grab a trash bag. A dumpster can only be collected once per route, and you can only carry one bag at a time.
+
+```lua title="Example"
+Config.Locations = {
+    Dumpsters = {
+        { coords = Vector(-360370, -132920, -2980), heading = 180 },
+        { coords = Vector(-360650, -130620, -2980), heading = 0 },
+        { coords = Vector(-358560, -129890, -2980), heading = 180 },
+        -- ...additional dumpsters...
+    },
+}
+```
+
+/// info
+Collecting gives the player an `ID_Misc_TrashBag` item via the inventory; depositing it at the truck removes the item, increments the stop counter, and adds a random `BagLowerWorth`–`BagUpperWorth` payout to the route. The full accumulated total is paid to the player's `bank` balance when the route is completed.
+///

--- a/docs/qbcore/qbcore-packages/qb-mining.md
+++ b/docs/qbcore/qbcore-packages/qb-mining.md
@@ -1,0 +1,97 @@
+# ⛏️ qb-mining
+Rock and stone!
+
+## Introduction
+Spawns minable rocks across configured zones. Players use [qb-target](qb-target.md) to interact with a rock, complete a minigame, and receive a weighted ore reward delivered through [qb-inventory](qb-inventory.md).
+
+The mining loop is:
+
+1. Rocks are scattered randomly inside each `miningZone` (weighted by `rockTypes`).
+2. The player targets a rock and selects **Mine Rock**, which is briefly given a jackhammer (`ID_Misc_Jackhammer`) and opens the mining minigame (a `WebUI` panel).
+3. On a successful minigame the server adds the rock's ore item to the player's inventory and removes the rock.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Global Options
+- NetworkedRocks: `boolean`
+- miningTime: `number`
+
+When `NetworkedRocks` is `true`, rocks are spawned once on the server and shared with every player (mined rocks are removed for everyone). When `false`, each client spawns its own local rocks. `miningTime` is the duration in milliseconds used by the minigame.
+
+```lua title="Example"
+Config = {
+    NetworkedRocks = true,
+    miningTime = 5000,
+}
+```
+
+### Mining Zones
+Each entry in `miningZones` defines a circular area that rocks are randomly placed inside.
+
+- id: `number`
+- name: `string`
+- center: `vector`
+- radius: `number`
+- maxRocks: `number`
+- minDistanceBetweenRocks: `number`
+- rockTypes: `table`
+
+`maxRocks` is the number of rocks the zone attempts to place, `radius` is how far from `center` they can spawn, and `minDistanceBetweenRocks` keeps them spaced apart.
+
+### Rock Types
+Each `rockTypes` entry is a possible ore the zone can spawn. Which rock type is picked for each rock is decided by `weight` (higher weight = more common).
+
+- mesh: `string`
+- item: `string`
+- weight: `number`
+- scale: `vector`
+
+`mesh` is the UE static mesh path used for the rock, `item` is the inventory item awarded when it is mined, and `scale` sizes the spawned mesh.
+
+```lua title="Example"
+Config = {
+    NetworkedRocks = true,
+    miningTime = 5000,
+    miningZones = {
+        {
+            id = 1,
+            name = 'Main Mining Area',
+            center = Vector(575778, 620372, 4440),
+            radius = 1000,
+            maxRocks = 25,
+            minDistanceBetweenRocks = 200,
+            rockTypes = {
+                {
+                    mesh = '/Game/Pacifica/Environment/Mesh/Rock/Tropical/SM_Beach_Rock_02A.SM_Beach_Rock_02A',
+                    item = 'copper_ore',
+                    weight = 40,
+                    scale = Vector(2.0, 2.0, 2.0)
+                },
+                {
+                    mesh = '/Game/Pacifica/Environment/Mesh/Rock/Tropical/SM_Beach_Rock_02A.SM_Beach_Rock_02A',
+                    item = 'gold_ore',
+                    weight = 35,
+                    scale = Vector(2.0, 2.0, 2.0)
+                },
+                {
+                    mesh = '/Game/Pacifica/Environment/Mesh/Rock/Tropical/SM_Beach_Rock_02A.SM_Beach_Rock_02A',
+                    item = 'diamond',
+                    weight = 25,
+                    scale = Vector(2.0, 2.0, 2.0)
+                },
+                {
+                    mesh = '/Game/Pacifica/Environment/Mesh/Rock/Tropical/SM_Beach_Rock_02A.SM_Beach_Rock_02A',
+                    item = 'iron_ore',
+                    weight = 45,
+                    scale = Vector(2.0, 2.0, 2.0)
+                },
+            }
+        }
+    }
+}
+```
+
+/// tip
+Every `item` you list under `rockTypes` must also exist in the qb-core `Shared.Items` table, otherwise the reward cannot be added to the player's inventory.
+///

--- a/docs/qbcore/qbcore-packages/qb-phone.md
+++ b/docs/qbcore/qbcore-packages/qb-phone.md
@@ -1,0 +1,32 @@
+# 📱 qb-phone
+There's an app for that
+
+## Introduction
+qb-phone is the in-game smartphone, opened with the **O** key. Opening the phone equips the `ID_Misc_Phone` item, so a player needs that item to use it. Most of the phone's data is database-driven (contacts, messages, mail, tweets, calendar, photos), so the config itself is minimal.
+
+The phone bundles several apps:
+
+- **Messages** — text conversations with other players, saved per contact
+- **Contacts** — saved contacts keyed by phone number
+- **Calls** — dial, ring, accept, and hang up; connected calls use HELIX voice channels so both parties can talk
+- **Gene** — a social feed of posts (tweets) with comments
+- **Hmail** — an email inbox (read/star mail)
+- **Calendar** — personal events with date, time, and details
+- **Gallery / Camera** — take front/back photos with the phone camera and store them in the gallery
+- **Money transfer** — send bank money to another player by their phone number
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### OpenKey
+The key used to open and close the phone. This is essentially the entire config — everything else the phone shows is loaded from the database at runtime.
+
+```lua title="Example"
+Config = {
+    OpenKey = 'O'
+}
+```
+
+/// info
+There are no other config options. Contacts, conversations, mail, calendar events, gallery photos, and the social feed all live in their respective database tables and are loaded when the phone is opened.
+///

--- a/docs/qbcore/qbcore-packages/qb-policejob.md
+++ b/docs/qbcore/qbcore-packages/qb-policejob.md
@@ -1,0 +1,148 @@
+# 🚓 qb-policejob
+Put your hands where I can see them!
+
+## Introduction
+
+The law enforcement job. Provides everything an on-duty officer needs to police the city:
+
+- Duty toggle, police garage and personal/evidence stashes at the station
+- Grade-gated police vehicles and helicopters spawned with a `PD` plate
+- Suspect interactions via [qb-target](qb-target.md) on other players: jail, view info, search, escort, handcuff, put in vehicle and check status
+- A `handcuffs` useable item that cuffs the nearest player
+- Fingerprint scanner (WebUI), evidence drawers and a status/injury check system
+- Configurable speed/security camera coordinates and ammo labels
+
+/// warning
+The CCTV/security-camera viewer (`Client/cctv.lua`) and the chat commands (`Server/commands.lua` — `/cam`, `/911p`, `/tracker`) are fully commented out in this port. The camera coordinates remain in `config.lua`, but there is no working in-game way to view them yet.
+///
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Items & Ranks
+The handcuff item that officers use, and the minimum grade required to run/manage licenses.
+
+```lua title="Example"
+Config.HandCuffItem = 'handcuffs',
+Config.LicenseRank = 2,
+```
+
+The `handcuffs` item is registered as a useable item that triggers the cuffing logic, and the cuffed state is exposed through the `IsHandcuffed` export (see [Functions](#functions)).
+
+### Ammo Labels
+Maps ammo type identifiers to human-readable labels, used when logging/displaying recovered ammunition during evidence work.
+
+```lua title="Example"
+Config.AmmoLabels = {
+    AMMO_PISTOL  = '9x19mm parabellum bullet',
+    AMMO_SMG     = '9x19mm parabellum bullet',
+    AMMO_RIFLE   = '7.62x39mm bullet',
+    AMMO_MG      = '7.92x57mm mauser bullet',
+    AMMO_SHOTGUN = '12-gauge bullet',
+    AMMO_SNIPER  = 'Large caliber bullet',
+}
+```
+
+### Objects
+Placeable scene objects (cones, barriers, road signs, tents, lights). Each entry takes a mesh `model` and a `freeze` flag.
+
+```lua title="Example"
+Config.Objects = {
+    cone     = { model = '', freeze = true },
+    barrier  = { model = '', freeze = true },
+    roadsign = { model = '', freeze = true },
+    tent     = { model = '', freeze = true },
+    light    = { model = '', freeze = true },
+}
+```
+
+### Locations
+Defines the station interaction points. `duty`, `vehicle`, `stash`, `fingerprint`, `evidence` and `stations` drive the in-world targets, while `impound`, `helicopter` and `trash` are placeholders shipped as `Vector(0, 0, 0)` to be set per-map.
+
+- coords: `Vector`
+- <mark style="color:yellow;">rotation</mark>: `Rotator`
+- <mark style="color:yellow;">heading</mark>: `number`
+- <mark style="color:yellow;">spawn</mark>: `table` (vehicle spawn `coords` + `rotation`)
+- <mark style="color:yellow;">label</mark>: `string` (stations)
+
+```lua title="Example"
+Config.Locations = {
+    duty = {
+        { coords = Vector(-340320.0, -147790.0, -2840.0), rotation = Rotator(0, 90, 90) },
+    },
+    vehicle = {
+        {
+            coords = Vector(-339350.0, -145760.0, -2970.0),
+            rotation = Rotator(0, 0, 0),
+            spawn = { coords = Vector(-339358.10, -144656.62, -2980.06), rotation = Rotator(0, 90, 0) },
+        },
+    },
+    stash = {
+        { coords = Vector(-339520.0, -148650.0, -2930.0), rotation = Rotator(0, 90, 0) },
+    },
+    fingerprint = {
+        { coords = Vector(-339884.98, -148380.16, -2889.0), rotation = Rotator(0, 90, 0) },
+    },
+    evidence = {
+        { coords = Vector(-339641.0, -149006.58, -2912.50), heading = 0 },
+    },
+    stations = {
+        { label = 'Police Station', coords = Vector(-340540.36, -147839.66, -2884.60) },
+    },
+    impound    = { Vector(0, 0, 0) }, -- placeholder, set per-map
+    helicopter = { Vector(0, 0, 0) }, -- placeholder, set per-map
+    trash      = { Vector(0, 0, 0) }, -- placeholder, set per-map
+}
+```
+
+### Authorized Vehicles & Helicopters
+Grade-gated spawn lists. The grade is the table key and acts as a minimum — higher ranks can also spawn anything available to lower grades. Spawned vehicles receive a `PD` plate followed by four random digits.
+
+```lua title="Example"
+Config.AuthorizedVehicles = {
+    [0] = {
+        ['bp_police'] = 'Police Car'
+    },
+}
+
+Config.AuthorizedHelicopters = {
+    [0] = {
+        ['bp_pheli'] = 'Police Heli'
+    }
+}
+```
+
+### Cameras
+Speed-camera and security-camera coordinates.
+
+/// warning
+These coordinates are read by the (currently disabled) CCTV code only. Editing them has no in-game effect until the camera viewer is enabled.
+///
+
+```lua title="Example"
+Config.SpeedCamera = {
+    Vector(13438.7, -46440.2, 209.7)
+}
+
+Config.SecurityCameras = {
+    cameras = {
+        { label = 'Hansons',         coords = Vector(16386.9, -46857.0, 400),  rotation = Rotator(0.0, 48.991352081299, 0.0),  canRotate = false, isOnline = true },
+        { label = 'Eastside Market', coords = Vector(-54437.3, -41350.1, 400), rotation = Rotator(0.0, -139.79696655273, 0.0), canRotate = false, isOnline = true },
+    },
+}
+```
+
+## Functions
+
+### IsHandcuffed
+Returns whether a player is currently handcuffed. Exported on both the server and the client.
+
+- CitizenId: `string` — _(server only)_ the citizen ID to check
+
+```lua title="Example"
+-- Server: check a specific player by citizen ID
+local cuffed = exports['qb-policejob']:IsHandcuffed(citizenid)
+
+-- Client: check the local player
+local cuffed = exports['qb-policejob']:IsHandcuffed()
+```

--- a/docs/qbcore/qbcore-packages/qb-radialmenu.md
+++ b/docs/qbcore/qbcore-packages/qb-radialmenu.md
@@ -1,0 +1,142 @@
+# 🛞 qb-radialmenu
+Round and round we go
+
+## Introduction
+qb-radialmenu is a wheel-style interaction menu opened with the **H** key. It presents context-aware options grouped into categories, letting players perform actions like clothing toggles, vehicle door/extra controls, and job-specific interactions. The menu is built from a configurable tree and automatically adds a **Work** submenu based on the player's current job.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Keybind
+The key used to open (and, in toggle mode, close) the radial menu.
+
+```lua title="Example"
+Config.Keybind = 'H'
+```
+
+### Toggle
+When `true`, pressing the key toggles the menu open/closed. When `false`, the key must be held to keep the menu open.
+
+```lua title="Example"
+Config.Toggle = false
+Config.UseWhilstWalking = false
+Config.EnableExtraMenu = true
+Config.Fliptime = 15000
+```
+
+### MenuItems
+The main menu tree. Each entry is a category with an `id`, `title`, `icon`, and either an `items` array (a submenu) or a leaf option. A leaf option defines a `type` (`'client'` or `'server'`), the `event` to trigger, and whether selecting it should close the menu (`shouldClose`). Submenus can be nested arbitrarily deep.
+
+```lua title="Example"
+Config.MenuItems = {
+    {
+        id = 'citizen',
+        title = 'Citizen',
+        icon = 'user',
+        items = {
+            {
+                id = 'givenum',
+                title = 'Give Contact Details',
+                icon = 'address-book',
+                type = 'client',
+                event = 'qb-phone:client:GiveContactDetails',
+                shouldClose = true
+            },
+            -- ...nested submenus and further options
+        }
+    }
+}
+```
+
+### JobInteractions
+A map of job name to a list of menu options. When the player is on a job that has an entry here, those options are added under a generated **Work** submenu. Leadership/LEO-typed jobs are mapped to the `police` key.
+
+```lua title="Example"
+Config.JobInteractions = {
+    ['ambulance'] = {
+        {
+            id = 'emergencybutton2',
+            title = 'Emergency button',
+            icon = 'bell',
+            type = 'client',
+            event = 'police:client:SendPoliceEmergencyAlert',
+            shouldClose = true
+        }
+    },
+    ['taxi'] = {
+        {
+            id = 'togglemeter',
+            title = 'Show/Hide Meter',
+            icon = 'eye-slash',
+            type = 'client',
+            event = 'qb-taxijob:client:toggleMeter',
+            shouldClose = false
+        }
+    }
+}
+```
+
+/// info
+**Adding your own options.** qb-radialmenu does **not** expose `AddOption` / `RemoveOption` exports — those functions are internal to the resource. The supported way to add interactions is to append entries to `Config.JobInteractions` (for job-gated options) or to `Config.MenuItems` (for always-available options) in the config. For example, to give a custom job its own Work submenu:
+
+```lua title="Example"
+Config.JobInteractions['mechanic'] = {
+    {
+        id = 'towvehicle',
+        title = 'Tow vehicle',
+        icon = 'truck-pickup',
+        type = 'client',
+        event = 'qb-tow:client:TowVehicle',
+        shouldClose = true
+    }
+}
+```
+///
+
+### VehicleDoors / VehicleExtras / VehicleSeats
+Predefined submenus for vehicle interaction. `VehicleDoors` lists each door (driver, passenger, rear, hood, trunk) pointing at `qb-radialmenu:client:openDoor`. `VehicleExtras` exposes extras 1–13 via `qb-radialmenu:client:setExtra`. `VehicleSeats` is a seat-change submenu populated at runtime.
+
+```lua title="Example"
+Config.VehicleDoors = {
+    id = 'vehicledoors',
+    title = 'Vehicle Doors',
+    icon = 'car-side',
+    items = {
+        {
+            id = 'door0',
+            title = 'Drivers door',
+            icon = 'car-side',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }
+        -- ...remaining doors
+    }
+}
+```
+
+### Commands / ExtraCommands
+Clothing toggle definitions used by the clothing radial actions and the extra menu. Each entry maps a clothing/prop slot to a toggle function, sprite, description, and (for `Commands`) a UI button index.
+
+```lua title="Example"
+Config.Commands = {
+    ['top'] = {
+        Func = function() ToggleClothing('Top') end,
+        Sprite = 'top',
+        Desc = 'Take your shirt off/on',
+        Button = 1,
+        Name = 'Torso'
+    }
+}
+
+Config.ExtraCommands = {
+    ['pants'] = {
+        Func = function() ToggleClothing('Pants', true) end,
+        Sprite = 'pants',
+        Desc = 'Take your pants off/on',
+        Name = 'Pants',
+        OffsetX = -0.04,
+        OffsetY = 0.0
+    }
+}
+```

--- a/docs/qbcore/qbcore-packages/qb-radio.md
+++ b/docs/qbcore/qbcore-packages/qb-radio.md
@@ -1,0 +1,52 @@
+# 📻 qb-radio
+Breaker, breaker
+
+## Introduction
+qb-radio is a voice radio that lets players talk to one another over a shared frequency. Opening the radio (default key **G**) brings up a UI where you can tune to a channel; joining a channel adds you to the matching HELIX voice channel so everyone on that frequency hears each other. Players need the `radio` item to use it.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### KeyBind
+The key used to open and close the radio UI.
+
+```lua title="Example"
+Config.KeyBind = 'G'
+```
+
+### RadioItem
+The inventory item required to operate the radio.
+
+```lua title="Example"
+Config.RadioItem = 'radio'
+```
+
+### RestrictedChannels
+A list of channels that are intended to be restricted to specific jobs. Each entry is a table of `job = true` flags for the jobs allowed on that channel.
+
+```lua title="Example"
+Config.RestrictedChannels = {
+    { police = true, ambulance = true },
+    { police = true, ambulance = true },
+    -- ...one entry per restricted channel
+}
+```
+
+/// note
+The job/on-duty enforcement against `RestrictedChannels` is currently commented out in the client, so channel access is not gated in this build. The table is still defined for when that check is re-enabled.
+///
+
+## How channels work
+Tuning to a frequency (a positive integer) calls the `JoinVoiceChannel` callback on the server, which adds you to the HELIX voice channel for that frequency. Tuning away or powering off calls `LeaveVoiceChannel`, removing you from it. You can step up or down a channel from the UI, and the radio reports the frequency in MHz when you join.
+
+## Functions
+
+### onRadio
+Returns whether the local player is currently connected to a radio channel. Useful for other resources (e.g. the HUD) to react to radio state.
+
+```lua title="Example"
+local talking = exports['qb-radio']:onRadio()
+if talking then
+    -- player is on a radio channel
+end
+```

--- a/docs/qbcore/qbcore-packages/qb-taxijob.md
+++ b/docs/qbcore/qbcore-packages/qb-taxijob.md
@@ -1,0 +1,59 @@
+# 🚕 qb-taxijob
+Where to, boss?
+
+## Introduction
+A taxi job where players clock in at a depot, grab a cab, and run a pickup/dropoff fare loop:
+
+- Talk to the Taxi Depot NPC to go on duty and take a taxi out.
+- An NPC passenger spawns at a random bus-stop bench. Drive to the highlighted pickup zone and press `[E]` to load them in.
+- A second bench is picked as the drop-off. Drive there and press `[E]` to let the passenger out.
+- The NUI fare meter tracks distance traveled and bills the rider per mile; the fare is paid into your bank, capped so the meter can't run wild.
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Vehicle, Rate and Fare Padding
+The top-level options set which vehicle the depot hands out, the fare charged per mile, and the multiplier used to cap the final payout against the straight-line distance between the pickup and drop-off benches.
+
+- Rate: `number` — price charged per mile traveled.
+- MaxFarePadding: `number` — multiplier applied to the base pickup-to-dropoff fare to set the maximum payout, accounting for turns and detours.
+
+```lua title="Example"
+Config = {
+    Vehicle = '/abcca-qbcore-veh/QBCoreVehicles/BP_Taxi.BP_Taxi_C',
+    Rate = 125.0,       -- price per mile
+    MaxFarePadding = 2, -- adjust this as needed to account for turns, etc.
+}
+```
+
+### Depots
+Each depot defines where the duty NPC stands (`pedSpawn`) and where the taxi spawns when you take a vehicle (`vehicleSpawn`). The NPC offers toggle-duty, take-vehicle, and finish-work target options.
+
+```lua title="Example"
+Config.Locations = {
+    Depots = {
+        {
+            label = 'Taxi Depot',
+            pedSpawn = { coords = Vector(-355290, -131250, -2880), heading = 165 },
+            vehicleSpawn = { coords = Vector(-355917, -130990, -2977), heading = 180 },
+        },
+    },
+}
+```
+
+### Benches
+Bus-stop benches double as both passenger pickup and drop-off points. Each is spawned as an `SM_BusStop` mesh. A random bench is chosen for the pickup and a different random bench for the drop-off on each fare.
+
+```lua title="Example"
+Config.Locations = {
+    Benches = {
+        { coords = Vector(-357440, -132210, -2970), heading = -90, npc = nil },
+        { coords = Vector(-357440, -122370, -2970), heading = -90, npc = nil },
+        { coords = Vector(-357440, -111940, -2970), heading = -90, npc = nil },
+    },
+}
+```
+
+/// info
+The fare meter is a `WebUI` panel (`qb-taxijob/html/index.html`). It tracks live distance from the vehicle position, multiplies miles by `Config.Rate`, and the drop-off payout is the lesser of the metered fare and the padded pickup-to-dropoff fare. Payouts are added to the player's `bank` balance.
+///

--- a/docs/qbcore/qbcore-packages/qb-vehicleshop.md
+++ b/docs/qbcore/qbcore-packages/qb-vehicleshop.md
@@ -1,0 +1,100 @@
+# 🚗 qb-vehicleshop
+Test drive it before you wreck it.
+
+## Introduction
+qb-vehicleshop runs the in-world car dealership. It spawns showroom vehicles on pedestals, lets players browse the catalog, swap which vehicle is on display, take it for a timed test drive, and buy it outright with cash or bank. Purchased vehicles are written to the `player_vehicles` database and become retrievable through [qb-garages](qb-garages.md).
+
+Vehicles come from the shared vehicle list (`exports['qb-core']:GetShared('Vehicles')`), so each entry's `label`, `price`, and `asset_name` are sourced from qb-core rather than configured here.
+
+/// warning
+Vehicle **financing is not implemented**. The config (`Config.FinanceCommission`, `Config.PaymentWarning`, `Config.PaymentInterval`, `Config.MinimumDown`, `Config.MaximumPayments`, `Config.PreventFinanceSelling`) and the locale strings exist as scaffolding, and a "Manage Financed Vehicles" target zone is registered, but there is no working finance/payment/repossession logic. Only **test drive**, **swap vehicle**, and **cash/bank purchase** actually work.
+///
+
+## Configuration
+All configurable options listed below are found in the `config.lua`
+
+### Commission & General
+Commission percentages and sale-behavior toggles.
+
+- Commission: `number` — fraction of a full cash sale paid to a salesperson (`0.10` = 10%)
+- <mark style="color:yellow;">FinanceCommission</mark>: `number` — scaffolded, finance is not implemented
+- <mark style="color:yellow;">PaymentWarning</mark>: `number` — scaffolded (minutes before repo)
+- <mark style="color:yellow;">PaymentInterval</mark>: `number` — scaffolded (hours between payments)
+- <mark style="color:yellow;">MinimumDown</mark>: `number` — scaffolded (minimum down-payment percent)
+- <mark style="color:yellow;">MaximumPayments</mark>: `number` — scaffolded (max number of payments)
+- <mark style="color:yellow;">PreventFinanceSelling</mark>: `boolean` — scaffolded
+- FilterByMake: `boolean` — show a make list before the category menu
+- SortAlphabetically: `boolean` — sort make/category/vehicle menus alphabetically
+- HideCategorySelectForOne: `boolean` — hide the category menu when only one category is sold
+
+```lua title="Example"
+Config.Commission = 0.10
+Config.FinanceCommission = 0.05
+Config.PaymentWarning = 10
+Config.PaymentInterval = 24
+Config.MinimumDown = 10
+Config.MaximumPayments = 24
+Config.PreventFinanceSelling = false
+Config.FilterByMake = false
+Config.SortAlphabetically = true
+Config.HideCategorySelectForOne = true
+```
+
+### Shops
+`Config.Shops` is a table indexed by a unique shop id (the stock dealership id is `'pdm'`). Each shop defines its type, the zones used for spawning and test-driving, and the showroom display vehicles.
+
+- Type: `string` — sale model (`'free-use'`)
+- Job: `string` — required job, or `'none'` for open access
+- TestDriveTimeLimit: `number` — test-drive duration in minutes
+- ReturnLocation: `Vector` — where a finished test drive returns to
+- VehicleSpawn: `table` — where a purchased vehicle spawns (`location` `Vector`, `rotation` `Rotator`)
+- TestDriveSpawn: `table` — where a test-drive vehicle spawns (`location` `Vector`, `rotation` `Rotator`)
+- <mark style="color:yellow;">FinanceZone</mark>: `Vector` — registers a "Manage Financed Vehicles" target (finance is not implemented)
+- ShowroomVehicles: `table` — the display pedestals (see below)
+
+```lua title="Example"
+Config.Shops = {
+    ['pdm'] = {
+        ['Type'] = 'free-use',
+        ['Job'] = 'none',
+        ['TestDriveTimeLimit'] = 0.5,
+        ['ReturnLocation'] = Vector(566599, 543296, 4564),
+        ['VehicleSpawn'] = {
+            location = Vector(566528, 542426, 4467),
+            rotation = Rotator(0, -90, 0)
+        },
+        ['TestDriveSpawn'] = {
+            location = Vector(566528, 542426, 4467),
+            rotation = Rotator(0, -90, 0)
+        },
+        ['FinanceZone'] = Vector(567958, 543877, 4564),
+        ['ShowroomVehicles'] = {
+            -- see below
+        },
+    },
+}
+```
+
+### Showroom Vehicles
+Each entry in a shop's `ShowroomVehicles` is a display pedestal. A static vehicle is spawned at `coords` on resource start, and a [qb-target](qb-target.md) box zone is attached offering **Test Drive**, **Swap Vehicle**, and **Purchase Vehicle**. Swapping replaces `chosenVehicle` (the one that gets test-driven or bought) without changing `defaultVehicle`.
+
+- coords: `table` — display position (`location` `Vector`, `rotation` `Rotator`)
+- defaultVehicle: `string` — vehicle spawned on the pedestal at start, keyed into the shared `Vehicles` list
+- chosenVehicle: `string` — the currently selected vehicle (updated by Swap)
+
+```lua title="Example"
+['ShowroomVehicles'] = {
+    {
+        coords = {
+            location = Vector(567561, 545062, 4470),
+            rotation = Rotator(0, 0, 0)
+        },
+        defaultVehicle = 'bp_merc',
+        chosenVehicle = 'bp_merc',
+    },
+},
+```
+
+/// tip
+Purchase uses the `price` from the shared `Vehicles` entry. The server pays from `cash` if the player can afford it, otherwise `bank`; if neither covers the price the sale is rejected. On success a plate is generated, the vehicle is inserted into `player_vehicles` (garage `'apartments'`), and a fueled vehicle spawns at the shop's `VehicleSpawn`.
+///


### PR DESCRIPTION
## Add the 16 missing qbcore-packages documentation pages

This PR fills in the qbcore-packages reference pages that were missing from the portal. The `qbcore-packages/` section previously documented 14 of the 30 packages in [`qbcore-rp`](https://github.com/hypersonic-laboratories/qbcore-rp); this adds the remaining **16**:

`qb-admin` · `qb-ambulancejob` · `qb-consumables` · `qb-core` · `qb-deliveryjob` · `qb-fishing` · `qb-fuel` · `qb-garages` · `qb-garbagejob` · `qb-mining` · `qb-phone` · `qb-policejob` · `qb-radialmenu` · `qb-radio` · `qb-taxijob` · `qb-vehicleshop`

### How these were written
- **Grounded in the actual `qbcore-rp` source** (config.lua / client.lua / server.lua / locales), not assumptions — config fields, example values, export names, and event names are taken verbatim from the code.
- **Match the existing page template**: emoji H1 + one-line tagline, `## Introduction`, `## Configuration` with real `lua title="Example"` blocks, a `## Functions` section only where the package actually exposes exports (e.g. `qb-core`, `qb-radio`, `qb-garages`), and `///` pymdownx admonitions.
- New files auto-register in the nav via the existing `... | flat | qbcore/qbcore-packages/*.md` glob — **no `mkdocs.yml` change needed**.

### Reviewer notes — features documented honestly as incomplete
A few packages are stubs or partially implemented in the current build; the pages say so plainly rather than documenting phantom behavior. Please sanity-check these calls:
- **qb-fuel** — pump `qb-target` options exist but point at an empty `'qb-fuel:'` event; **no working refuel/jerry-can/payment** yet. Documented as a work-in-progress.
- **qb-vehicleshop** — vehicle **financing** is scaffolded in config/locale but **not implemented**; test drive, swap, and cash/bank purchase do work.
- **qb-admin** — there is **no permission/ACE gate in the code** and the F3 keybind + admin events are unguarded; several actions (spectate, ban persistence, etc.) are `TO DO` stubs. Flagged in-page; worth a security follow-up upstream.
- **qb-radio** — the `RestrictedChannels` job check is commented out in this build (noted).
- **qb-policejob** — CCTV and the `/cam` `/911p` `/tracker` chat commands are commented out (noted).
- **qb-ambulancejob** — all location coords ship as `Vector(0,0,0)` placeholders to be set per-map (noted).

### Notes
- American spelling, factual tone, consistent with the existing pages.
- Happy to adjust depth, tone, or per-page structure based on review — these are intended to slot straight into the portal.

_Drafted with assistance from Claude (Cowork), reviewed against the live codebase. Opening as a branch/PR specifically so the docs portal's main contributors can review before merge._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hypersonic-laboratories/codesmith/helix-documentation/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783024643&installation_id=136299171&pr_number=60&repository=hypersonic-laboratories%2Fhelix-documentation&return_to=https%3A%2F%2Fgithub.com%2Fhypersonic-laboratories%2Fhelix-documentation%2Fpull%2F60&signature=89b840ca4dff884f8ecfff3a3f7da2207e5930fdcceb1ff956d1ad7d171a0352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->